### PR TITLE
chore(release): add version to release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 terraform.tfstate*
 .terraform/
+dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 1.0.0 - 2019-10-01
+
+### Changed
+
+- Introduce go.mod to manage go modules
+- Upgrade terraform SDK to 0.12 for terraform upgrade
+- Add and changelog and version number to provider
+- Update `make install` to install to the terraform plugins folder directly
+- Add `make dev-install` to test your local build
+- Add `make release` command and release directory

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 GOPACKAGES = "github.com/circleci/terraform-provider-twistlock/..."
+NAME = "terraform-provider-twistlock"
+VERSION = "v1.0.0"
+
+OS_NAME := $(shell uname -s | tr A-Z a-z)
 
 build:
-	go build
+	go build -o $(NAME)_$(VERSION)
 
 test:
 	go test -coverprofile=coverage.out -covermode=count -v $(GOPACKAGES)
@@ -17,6 +21,21 @@ fmt:
 # accordingly
 check: test fmt
 
+release:
+	rm -rf dist
+	mkdir -p dist
+
+	GOOS=linux GOARCH=amd64 go build -o $(NAME)_$(VERSION)
+	tar czf dist/$(NAME)-$(VERSION)-linux-amd64.tar.gz $(NAME)_$(VERSION)
+
+	GOOS=darwin GOARCH=amd64 go build -o $(NAME)_$(VERSION)
+	tar czf dist/$(NAME)-$(VERSION)-darwin-amd64.tar.gz $(NAME)_$(VERSION)
+
 install:
-	go install
-	terraform init
+	mkdir -p ~/.terraform.d/plugins
+	wget -c https://github.com/circleci/terraform-provider-twistlock/releases/download/$(VERSION)/$(NAME)-$(VERSION)-$(OS_NAME)-amd64.tar.gz -O - | tar -xz -C ~/.terraform.d/plugins
+
+dev-install:
+	mkdir -p ~/.terraform.d/plugins
+	make build
+	mv $(NAME)_$(VERSION) ~/.terraform.d/plugins

--- a/README.md
+++ b/README.md
@@ -1,13 +1,9 @@
 # Terraform Twistlock Provider
 
 ## Installing the plugin
-```bash
-$ go get -u github.com/circleci/terraform-provider-twistlock
-```
 
-Make sure that `${GOPATH}/bin` is on your `${PATH}`, if not add it:
 ```bash
-$ export PATH=${PATH}:${GOPATH}/bin
+make install
 ```
 
 Call `terraform init` before running other Terraform commands in a directory
@@ -15,31 +11,61 @@ that contains Twistlock configuration. Terraform will tell you to do this if it
 hasn't configured the Twistlock plugin before, or if you have upgraded the
 plugin.
 
-
 ## Building the provider locally
+
 ```bash
-$ make install
+make build
 ```
 
-## Running tests
+Make sure that `${GOPATH}/bin` is on your `${PATH}`, if not add it:
+
 ```bash
-$ make test
+export PATH=${PATH}:${GOPATH}/bin
+```
+
+### Testing your local build with Terraform
+
+```bash
+make dev-install
+```
+
+And then run terraform command in your project.
+
+## Creating release package
+
+```bash
+make release
+```
+
+Now we can create release package from local, and then upload to GitHub
+release page manually
+
+## Running tests
+
+```bash
+make test
 ```
 
 ## Running acceptance tests
+
 Acceptance tests require a local running Twistlock Console.
 
 Export env-vars to configure the provider
+
 ```bash
-$ export HISTCONTROL=ignorespace
-$   export TWISTLOCK_USERNAME='user'
-$   export TWISTLOCK_PASSWORD='password'
-$   export TWISTLOCK_BASE_URL=http://localhost:8081/api/v1
+export HISTCONTROL=ignorespace
+
+# leading space here can be used to ignore these commands stored in the shell
+# command history when you set "HISTCONTROL=ignorespace" above
+ export TWISTLOCK_USERNAME='user'
+ export TWISTLOCK_PASSWORD='password'
+ export TWISTLOCK_BASE_URL=http://localhost:8081/api/v1
 ```
 
 Run tests with
+
 ```bash
-$ make acceptance-test
+make acceptance-test
 ```
 
 ### Re-generating keys for the User resource tests
@@ -49,16 +75,18 @@ to verify that the encrypted, generated password can be decrypted.
 
 The secret key must have no passphrase in order to be usable during tests
 
-Re-generate the keys with:
+Re-generate the keys in the `macOS`:
+
 ```bash
-$ gpg --batch --gen-key gpg-key-generate.control
-$ gpg --export terraform-provider-twistlock@acceptance.test | base64 --break=76 > twistlock/testdata/test-gpg-keys/terraform.pub
-$ gpg --export-secret-keys terraform-provider-twistlock@acceptance.tes | base64 --break=76 > twistlock/testdata/test-gpg-keys/terraform.priv
-$ gpg --delete-secret-and-public-key terraform-provider-twistlock@acceptance.test
+gpg --batch --gen-key gpg-key-generate.control
+gpg --export terraform-provider-twistlock@acceptance.test | base64 --break=76 > twistlock/testdata/test-gpg-keys/terraform.pub
+gpg --export-secret-keys terraform-provider-twistlock@acceptance.tes | base64 --break=76 > twistlock/testdata/test-gpg-keys/terraform.priv
+gpg --delete-secret-and-public-key terraform-provider-twistlock@acceptance.test
 ```
 
 ## Sample terraform file
-```
+
+```terraform
 provider "twistlock" {
   "username" = "gordon"
   "password" = "gordon"


### PR DESCRIPTION
We want to make version to our twistlock provider for better dependency
management. And to make better development experience, we add some make
commands.

**Changes**

1. Add and changelog and version number to provider
2. Update make `install` to install to the terraform plugins folder directly
3. Add `make release` command and release directory
4. Add `make dev-install` command for local test