### PR TITLE
fix(SRE-1542,cve_policy,read): fix unsync from actual state bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.1.0 - 2019-10-06
+
+### Fixed
+
+- Fix bug about can not detect changes from actual service configuration
+
 ## 1.0.0 - 2019-10-01
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GOPACKAGES = "github.com/circleci/terraform-provider-twistlock/..."
 NAME = "terraform-provider-twistlock"
-VERSION = "v1.0.0"
+VERSION = "v1.1.0"
 
 OS_NAME := $(shell uname -s | tr A-Z a-z)
 

--- a/model/cve_policy_test.go
+++ b/model/cve_policy_test.go
@@ -1,0 +1,288 @@
+package model
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestConverter(t *testing.T) {
+	cases := []struct {
+		input    []string
+		expected []interface{}
+	}{
+		{
+			[]string{},
+			[]interface{}{},
+		},
+		{
+			[]string{"a", "b", "c"},
+			[]interface{}{"a", "b", "c"},
+		},
+	}
+
+	for _, c := range cases {
+		actual := converter(c.input)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("Actual = %v; Expected = %v", actual, c.expected)
+		}
+	}
+}
+
+func TestFlattenRuleResources(t *testing.T) {
+	cases := []struct {
+		input    map[string][]string
+		expected []interface{}
+	}{
+		{
+			map[string][]string{
+				"hosts":      []string{"a", "b", "c"},
+				"images":     []string{"a", "b", "c"},
+				"labels":     []string{"a", "b", "c"},
+				"containers": []string{"a", "b", "c"},
+			},
+			[]interface{}{
+				map[string][]interface{}{
+					"hosts":      converter([]string{"a", "b", "c"}),
+					"images":     converter([]string{"a", "b", "c"}),
+					"labels":     converter([]string{"a", "b", "c"}),
+					"containers": converter([]string{"a", "b", "c"}),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := flattenRuleResources(c.input)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("Actual = %v; Expected = %v", actual, c.expected)
+		}
+	}
+}
+
+func TestFlattenCVEVul(t *testing.T) {
+	cases := []struct {
+		input    CVEVulnerability
+		expected map[string]interface{}
+	}{
+		{
+			CVEVulnerability{
+				ID:              410,
+				Block:           false,
+				MinimumSeverity: CVSSv3(0),
+			},
+			map[string]interface{}{
+				"id":               410,
+				"block":            false,
+				"minimum_severity": CVSSv3(0),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := flattenCVEVul(c.input)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("Actual = %v; Expected = %v", actual, c.expected)
+		}
+	}
+}
+
+func TestFlattenRuleConditionVulnerabilities(t *testing.T) {
+	cases := []struct {
+		input    []CVEVulnerability
+		expected []interface{}
+	}{
+		{
+			[]CVEVulnerability{
+				CVEVulnerability{
+					ID:              410,
+					Block:           false,
+					MinimumSeverity: CVSSv3(0),
+				},
+				CVEVulnerability{
+					ID:              411,
+					Block:           true,
+					MinimumSeverity: CVSSv3(10),
+				},
+			},
+			[]interface{}{
+				flattenCVEVul(
+					CVEVulnerability{
+						ID:              410,
+						Block:           false,
+						MinimumSeverity: CVSSv3(0),
+					},
+				),
+				flattenCVEVul(
+					CVEVulnerability{
+						ID:              411,
+						Block:           true,
+						MinimumSeverity: CVSSv3(10),
+					},
+				),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := flattenRuleConditionVulnerabilities(c.input)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("Actual = %v; Expected = %v", actual, c.expected)
+		}
+	}
+}
+
+func TestFlattenRuleConditionCVEs(t *testing.T) {
+	cases := []struct {
+		input    CVERule
+		expected []interface{}
+	}{
+		{
+			CVERule{
+				IDs:       []string{"a", "b", "c"},
+				Effect:    CVEEffect("ignore"),
+				OnlyFixed: false,
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"ids":        converter([]string{"a", "b", "c"}),
+					"effect":     CVEEffect("ignore"),
+					"only_fixed": false,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := flattenRuleConditionCVEs(c.input)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("Actual = %v; Expected = %v", actual, c.expected)
+		}
+	}
+}
+
+func TestFlattenRuleCondition(t *testing.T) {
+	cases := []struct {
+		input    CVECondition
+		expected []interface{}
+	}{
+		{
+			CVECondition{
+				Vulnerabilities: []CVEVulnerability{
+					CVEVulnerability{
+						ID:              410,
+						Block:           false,
+						MinimumSeverity: CVSSv3(0),
+					},
+				},
+				CVEs: CVERule{
+					IDs:       []string{"a", "b", "c"},
+					Effect:    CVEEffect("ignore"),
+					OnlyFixed: false,
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"vulnerabilities": []interface{}{
+						flattenCVEVul(
+							CVEVulnerability{
+								ID:              410,
+								Block:           false,
+								MinimumSeverity: CVSSv3(0),
+							},
+						),
+					},
+					"cves": []interface{}{
+						map[string]interface{}{
+							"ids":        converter([]string{"a", "b", "c"}),
+							"effect":     CVEEffect("ignore"),
+							"only_fixed": false,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := flattenRuleCondition(c.input)
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("Actual = %v; Expected = %v", actual, c.expected)
+		}
+	}
+}
+
+func TestFlatten(t *testing.T) {
+	cases := []struct {
+		input    CVEPolicyRule
+		expected map[string]interface{}
+	}{
+		{
+			CVEPolicyRule{
+				Owner: "systems",
+				Name:  "Default - alert all components",
+				Resources: map[string][]string{
+					"hosts":      []string{"*"},
+					"images":     []string{"*"},
+					"labels":     []string{"*"},
+					"containers": []string{"*"},
+				},
+				Condition: CVECondition{
+					Vulnerabilities: []CVEVulnerability{
+						CVEVulnerability{
+							ID:              410,
+							Block:           false,
+							MinimumSeverity: CVSSv3(0),
+						},
+					},
+					CVEs: CVERule{
+						IDs:       []string{"a", "b", "c"},
+						Effect:    CVEEffect("ignore"),
+						OnlyFixed: false,
+					},
+				},
+				Verbose: false,
+			},
+			map[string]interface{}{
+				"owner": "systems",
+				"name":  "Default - alert all components",
+				"resources": []interface{}{
+					map[string][]interface{}{
+						"hosts":      converter([]string{"*"}),
+						"images":     converter([]string{"*"}),
+						"labels":     converter([]string{"*"}),
+						"containers": converter([]string{"*"}),
+					},
+				},
+				"condition": []interface{}{
+					map[string]interface{}{
+						"vulnerabilities": []interface{}{
+							flattenCVEVul(
+								CVEVulnerability{
+									ID:              410,
+									Block:           false,
+									MinimumSeverity: CVSSv3(0),
+								},
+							),
+						},
+						"cves": []interface{}{
+							map[string]interface{}{
+								"ids":        converter([]string{"a", "b", "c"}),
+								"effect":     CVEEffect("ignore"),
+								"only_fixed": false,
+							},
+						},
+					},
+				},
+				"block_message": "",
+				"verbose":       false,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual := c.input.Flatten()
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("\nActual = %v;\nExpected = %v", actual, c.expected)
+		}
+	}
+}


### PR DESCRIPTION
**Why**

There is bug that we can not detect changes from actual service
config, so here is the fix

**Changes**

* use flatten func to help to refresh in-memory state in Read func,
because rules data structure is complex, we need to use flatten
helper function to implement this, more details, you can check:
https://www.terraform.io/docs/extend/writing-custom-providers.html#implementing-a-more-complex-read
* add more unit test for flatten functions
* add missing ID setup
* bumping version
* update changelog