### PR TITLE
Deprecate terraform-provider-twistlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Deprecated
+
+This repository is deprecated in favour of the official [Prisma Cloud provider](https://www.terraform.io/docs/providers/prismacloud/index.html).
+
 # Terraform Twistlock Provider
 
 ## Installing the plugin


### PR DESCRIPTION
## Description (*)

We are no longer using this provider, and there's an official provider in Terraform instead that can be used.

## Contribution checklist (*)
 - [x] I have read the Contributing Guidelines
 - [x] Commits have been made with meaningful commit messages
 - [N/A] All automated tests have passed successfully 
 
